### PR TITLE
Rename prepare script to avoid rebuilding dist on every npm install

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   ],
   "scripts": {
     "lint": "eslint --fix stacktrace-gps.js spec/",
-    "prepare": "cp stacktrace-gps.js polyfills.js dist/ && ./node_modules/.bin/webpack --mode production && uglifyjs node_modules/stackframe/stackframe.js ./build/bundle.js stacktrace-gps.js -o dist/stacktrace-gps.min.js --compress --mangle --source-map \"url=stacktrace-gps.min.js.map\" && uglifyjs node_modules/es6-promise/dist/es6-promise.js polyfills.js node_modules/stackframe/stackframe.js build/bundle.js stacktrace-gps.js -o dist/stacktrace-gps-with-polyfills.min.js --compress --mangle --source-map \"url=stacktrace-gps-polyfilled.min.js.map\"",
+    "build": "cp stacktrace-gps.js polyfills.js dist/ && ./node_modules/.bin/webpack --mode production && uglifyjs node_modules/stackframe/stackframe.js ./build/bundle.js stacktrace-gps.js -o dist/stacktrace-gps.min.js --compress --mangle --source-map \"url=stacktrace-gps.min.js.map\" && uglifyjs node_modules/es6-promise/dist/es6-promise.js polyfills.js node_modules/stackframe/stackframe.js build/bundle.js stacktrace-gps.js -o dist/stacktrace-gps-with-polyfills.min.js --compress --mangle --source-map \"url=stacktrace-gps-polyfilled.min.js.map\"",
     "test": "karma start karma.conf.js --single-run",
     "test-pr": "karma start karma.conf.js --single-run --browsers Firefox,Chrome_Travis",
     "test-ci": "karma start karma.conf.ci.js --single-run"


### PR DESCRIPTION
Possible fix for https://jira.carbonblack.local/browse/RE-9003

The `prepare` script may be causing build failures on our Jenkins runner - normally dependencies would not attempt to run their `prepare` script on install but npm has a special case for dependencies installed via git:
> [NOTE: If a package being installed through git contains a prepare script, its dependencies and devDependencies will be installed, and the prepare script will be run, before the package is packaged and installed.](https://docs.npmjs.com/cli/v6/using-npm/scripts#life-cycle-scripts)

Since the purpose of this script is to populate the `dist` folder, `build` seems to be an appropriate name & matches our convention in `defense-ui`
